### PR TITLE
Fixed too strict validation

### DIFF
--- a/components/dataentry/dataentry-controller.js
+++ b/components/dataentry/dataentry-controller.js
@@ -136,15 +136,17 @@ trackerCapture.controller('DataEntryController',
         if(!date) {
             return;
         }
-        if($scope.model.ouDates) {
+        if($scope.model.ouDates && $scope.model.ouDates.startDate && $scope.model.ouDates.endDate) {
             if (!DateUtils.verifyOrgUnitPeriodDate(date, $scope.model.ouDates.startDate, $scope.model.ouDates.endDate)) {
                 dateSetter($scope, null);
                 return;
             }
         }
 
-        if (!DateUtils.verifyExpiryDate(date, $scope.selectedProgram.expiryPeriodType, $scope.selectedProgram.expiryDays)) {
-            dateSetter($scope, null);
+        if($scope.selectedProgram.expiryPeriodType && $scope.selectedProgram.expiryDays) {
+            if (!DateUtils.verifyExpiryDate(date, $scope.selectedProgram.expiryPeriodType, $scope.selectedProgram.expiryDays)) {
+                dateSetter($scope, null);
+            }
         }
     };
     


### PR DESCRIPTION
This code was not working when the ouDates was not specified: The
$scope.model.ouDates was present in the model, but
$scope.model.ouDates.startDate and $scope.model.ouDates.endDate was
undefined.
At the same time $scope.selectedProgram.expiryPeriodType was undefined.
This caused a legal date to be dismissed by the saving mechanism.