### PR TITLE
Added different warning when canceling editing a profile on the dashboard

### DIFF
--- a/components/profile/profile-controller.js
+++ b/components/profile/profile-controller.js
@@ -9,6 +9,7 @@ trackerCapture.controller('ProfileController',
     $scope.editingDisabled = true;
     $scope.enrollmentEditing = false;
     $scope.widget = 'PROFILE';
+    $scope.isInDashboard = true;
     
     //listen for the selected entity
     var selections = {};

--- a/components/registration/registration-controller.js
+++ b/components/registration/registration-controller.js
@@ -568,7 +568,7 @@ trackerCapture.controller('RegistrationController',
         });
     };
 
-    $scope.cancelRegistrationWarning = function (cancelFunction) {
+    $scope.cancelRegistrationWarning = function (cancelFunction, inDashboard) {
         var result = RegistrationService.processForm($scope.tei, $scope.selectedTei, $scope.teiOriginal, $scope.attributesById);
         var prStDe;
         if (!result.formChanged) {
@@ -587,7 +587,8 @@ trackerCapture.controller('RegistrationController',
                 closeButtonText: 'no',
                 actionButtonText: 'yes',
                 headerText: 'cancel',
-                bodyText: 'are_you_sure_to_cancel_registration'
+                //Depending on if you are editing in dashboard or registering a new TEI you get a different cancel message.
+                bodyText: inDashboard ? 'are_you_sure_to_cancel_editing' : 'are_you_sure_to_cancel_registration'
             };
 
             ModalService.showModal({}, modalOptions).then(function () {

--- a/components/registration/registration.html
+++ b/components/registration/registration.html
@@ -89,7 +89,8 @@
         <!-- registration buttons begin -->
         <div ng-if="!editingDisabled && registrationMode === 'PROFILE'" class="vertical-spacing btn-group">
             <button type="button" class="btn btn-primary" ng-disabled="selectedOrgUnit.closedStatus" ng-click="registerEntity(null)">{{'save'| translate}}</button>
-            <button type="button" class="btn btn-default small-horizontal-spacing" ng-disabled="selectedOrgUnit.closedStatus" ng-click="cancelRegistrationWarning(cancel)">{{'cancel'| translate}}</button>
+            <button type="button" class="btn btn-default small-horizontal-spacing" ng-disabled="selectedOrgUnit.closedStatus" ng-click="cancelRegistrationWarning(cancel)" ng-if="!isInDashboard">{{'cancel'| translate}}</button>
+            <button type="button" class="btn btn-default small-horizontal-spacing" ng-disabled="selectedOrgUnit.closedStatus" ng-click="cancelRegistrationWarning(cancel, isInDashboard)" ng-if="isInDashboard">{{'cancel'| translate}}</button>
         </div>
 
         <div class="vertical-spacing btn-group" ng-if="registrationMode === 'ENROLLMENT'">            

--- a/i18n/i18n_app.properties
+++ b/i18n/i18n_app.properties
@@ -442,6 +442,7 @@ print_form=Print form
 value_must_be_email=Please enter a valid e-mail address
 click_to_edit_view_complete_notes=Click to edit/view complete notes
 complete_and_exit =Complete and exit
+are_you_sure_to_cancel_editing=Are you sure you want to cancel editing of this profile?
 are_you_sure_to_cancel_registration=Are you sure you want to cancel this registration?
 schedule=Schedule
 scheduled_date=Scheduled date


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-1029

Before the warning message was the same as if you would cancel registering a new TEI. It is now changed to:

> Are you sure you want to cancel editing of this profile?

Instead of:

> Are you sure you want to cancel this registration?

The improvement gives a clearer and more understandable warning to the user when he wants to cancel editing a profile in the dashboard.

![edit-warning](https://user-images.githubusercontent.com/6719078/29360709-82bd07c8-8284-11e7-81a0-709a09a0639e.gif)
