### PR TITLE
Fixed bug where cursor would disappear

### DIFF
--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -327,11 +327,11 @@
                 </span>
                 <div ng-messages="innerForm.foo.$error" ng-if="interacted(innerForm.foo)" class="required hideInPrint" ng-messages-include="../dhis-web-commons/angular-forms/error-messages.html">
                     <div class="alert alert-warning alert-dismissible" role="alert" ng-if="warningMessages[attribute.id]">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close" tabindex="-1"><span aria-hidden="true">&times;</span></button>
                         {{warningMessages[attribute.id]}}
                     </div>
                     <div class="alert alert-danger alert-dismissible" role="alert" ng-if="errorMessages[attribute.id]">
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close" tabindex="-1"><span aria-hidden="true">&times;</span></button>
                         {{errorMessages[attribute.id]}}
                     </div>
                 </div>


### PR DESCRIPTION
- The bug occurred when you edited an attribute with a warning message under it. Once value was corrected and you pressed tab the cursor would go to the close button on the warning before removing the warning, making the cursor disappear.

- Fixed the bug by making the close warnig button untabbable with the tabindex attribute.

**Result:**
![tab-bug-fix](https://user-images.githubusercontent.com/6719078/29407699-8cc9be02-8345-11e7-8a7e-27a9465f37b1.gif)
