### PR TITLE
Future date fix

### DIFF
--- a/components/dataentry/dataentry-controller.js
+++ b/components/dataentry/dataentry-controller.js
@@ -579,6 +579,10 @@ trackerCapture.controller('DataEntryController',
     $scope.isCompulsory = function(dataElement) {
         return $scope.currentStage.programStageDataElementsCollection[dataElement.id].compulsory;
     };
+
+    $scope.allowDateInFuture = function(dataElement) {
+        return $scope.currentStage.programStageDataElementsCollection[dataElement.id].allowFutureDate;
+    };
     
     //check if field is hidden
     $scope.isHidden = function (id, event) {
@@ -3227,5 +3231,5 @@ trackerCapture.controller('DataEntryController',
         for(var key in $scope.eventTableOptions){
             $scope.eventTableOptionsArr[$scope.eventTableOptions[key].sort] = $scope.eventTableOptions[key];
         }
-    }   
+    }
 });

--- a/components/dataentry/section-inner-form.html
+++ b/components/dataentry/section-inner-form.html
@@ -182,7 +182,7 @@
                        placeholder="{{dhis2CalendarFormat.keyDateFormat}}"
                        d2-date
                        d2-date-validator
-                       max-date="prStDes[de.id].allowFutureDate ? '' : 0"
+                       max-date="{{allowDateInFuture(de)}} ? '' : 0"
                        class="form-control"
                        ng-class="getInputNotifcationClass(de.id,false, currentEvent)"
                        ng-model="currentEvent[de.id]"

--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -50,6 +50,7 @@
                     </span>                    
                 </span>
 
+                <!-- attribute.allowFutureDate does not exist, that is why you can't select a date in the future -->
                 <span ng-if="!attribute.optionSetValue" ng-switch="attribute.valueType">
                     <span ng-switch-when="DATE">
                         <input type="text"

--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -50,7 +50,6 @@
                     </span>                    
                 </span>
 
-                <!-- attribute.allowFutureDate does not exist, that is why you can't select a date in the future -->
                 <span ng-if="!attribute.optionSetValue" ng-switch="attribute.valueType">
                     <span ng-switch-when="DATE">
                         <input type="text"


### PR DESCRIPTION
- Before: When the "_Date in Future_" checkbox was checked the data element would still not allow the future date to be set.

- Now: Once checked the data element allows dates to be set in future.

- Why: The **allowFutureDate** attribute is updated in a different place. So the system would check against an old value that would not be updated when the checkbox was checked.