### PR TITLE
chore: add stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,1 @@
+_extends: .github


### PR DESCRIPTION
Adds configuration for [probot-stale](https://github.com/probot/stale), a bot which comments on issues and PRs if they haven't had activity for >90 days. It then marks it as stale, and if no further action is taken, it closes the PR or issue in another 30 days.

Full configuration is here: https://github.com/dhis2/.github/blob/master/.github/stale.yml