### PR TITLE
Do not override currentStage on each iteration

### DIFF
--- a/components/dataentry/dataentry-controller.js
+++ b/components/dataentry/dataentry-controller.js
@@ -896,7 +896,7 @@ trackerCapture.controller('DataEntryController',
                 $scope.programStages = $scope.tabularEntryStages = $scope.selectedProgram.programStages;
                 
                 angular.forEach($scope.selectedProgram.programStages, function (stage) {
-                    if (stage.openAfterEnrollment) {
+                    if (!$scope.currentStage && stage.openAfterEnrollment) {
                         $scope.currentStage = stage;
                     }
 


### PR DESCRIPTION
Steps to reproduce:

- Create tracker program
- Set ``openAfterEnrollment`` to multiple program stages in the same tracker program
- Open Tracker Capture with Tabular Data Entry Widget and visit the new tracker program
- See that the last program stage with ``openAfterEnrollment`` property is selected

Expected behavior:

- The first program stage with ``openAfterEnrollment`` property should be selected (same behavior as Android app)

Solution:

- Before overriding ``currentStage`` in the state, check if it has already been defined in a previous iteration of the loop