### PR TITLE
V34 ks cluster updates

### DIFF
--- a/components/home/home-controller.js
+++ b/components/home/home-controller.js
@@ -300,10 +300,10 @@ trackerCapture.controller('HomeController',function(
           });
 
         $scope.shouldShowButton = function (view) {
-            if($scope.selectedProgram.id === INNREISE_PROGRAM_ID && view.name === 'Registrere') {
+            if($scope.selectedProgram && $scope.selectedProgram.id === INNREISE_PROGRAM_ID && view.name === 'Registrere') {
                 return false;
             }
-            if($scope.selectedProgram.id === DUPLIKAT_INNREISE_PROGRAM_ID && view.name === 'Registrere') {
+            if($scope.selectedProgram && $scope.selectedProgram.id === DUPLIKAT_INNREISE_PROGRAM_ID && view.name === 'Registrere') {
                 return false;
             }
             return true;

--- a/components/relationship/relationship-controller.js
+++ b/components/relationship/relationship-controller.js
@@ -205,12 +205,15 @@ trackerCapture.controller('RelationshipController',
             TEIService.getWithProgramData(relative.trackedEntityInstance, 'DM9n1bUw8W8', $scope.optionSets, $scope.attributesById).then(function(teiIndex){
                 angular.forEach(teiIndex.enrollments,function(enrollment) {
                     if(enrollment.program == 'DM9n1bUw8W8') {
-                        var contactDateMoment = moment(DateUtils.formatFromUserToApi(enrollment.enrollmentDate));
+                        var contactDateMoment;
 
                         angular.forEach(enrollment.events, function(event){
-                            if((!endDate || moment(event.eventDate).isBefore(endDate)) && moment(event.eventDate).isAfter(startDate) && event.programStage == 'sAV9jAajr8x' ) {
+                            if((!endDate || moment(event.eventDate).isBefore(endDate)) && (moment(event.eventDate).isAfter(startDate) || moment(event.eventDate).isSame(startDate)) && event.programStage == 'sAV9jAajr8x' ) {
                                 //this is the followup event in the contact program: event date is contact time.
-                                contactDateMoment = moment(event.eventDate);
+                                if (!contactDateMoment || moment(event.eventDate).isBefore(contactDateMoment)) {
+                                    //only update the contact date if it is older than the previous one, we want the first contact date that is relevant
+                                    contactDateMoment = moment(event.eventDate);
+                                }
                             }
                         });
 

--- a/components/relationship/relationship-controller.js
+++ b/components/relationship/relationship-controller.js
@@ -186,7 +186,7 @@ trackerCapture.controller('RelationshipController',
                 angular.forEach(teiIndex.enrollments,function(enrollment) {
                     if(enrollment.program == 'uYjxkTbwRNf') {
                         var symptomsOnsetMoment = moment(DateUtils.formatFromUserToApi(enrollment.incidentDate));
-                        if( !endDate ||  symptomsOnsetMoment.isBefore(endDate))
+                        if( (symptomsOnsetMoment.isSame(startDate) || symptomsOnsetMoment.isAfter(startDate)) && (!endDate ||  symptomsOnsetMoment.isBefore(endDate)))
                         {
                             relative.symptomsOnsetMoment = symptomsOnsetMoment;
                             relative.symptomsOnset = enrollment.incidentDate;


### PR DESCRIPTION
Fixed so older indexes is not concidered for a cluster. 
If more than one contact event falls in the cluster date range, only concider the first one when determining contact date.
Removed log noise from another change with a null check.