### PR TITLE
fix: cluster logic

### DIFF
--- a/components/relationship/relationship-controller.js
+++ b/components/relationship/relationship-controller.js
@@ -217,7 +217,7 @@ trackerCapture.controller('RelationshipController',
                             }
                         });
 
-                        if(!endDate || contactDateMoment.isBefore(endDate)) {
+                        if(contactDateMoment && (!endDate || contactDateMoment.isBefore(endDate))) {
                             relative.contactDateMoment = contactDateMoment
                             relative.contactDate = DateUtils.formatFromApiToUser(contactDateMoment);;
                             relative.created = DateUtils.formatFromApiToUser(contactDateMoment);;
@@ -226,8 +226,7 @@ trackerCapture.controller('RelationshipController',
                     //TODO: Check wether we keep the API behavior of returning other programs the user has access to as well as the requested program:
                     if(enrollment.program == 'uYjxkTbwRNf') {
                         var symptomsOnsetMoment = moment(DateUtils.formatFromUserToApi(enrollment.incidentDate));
-                        if( !endDate || symptomsOnsetMoment.isBefore(endDate) )
-                        {
+                        if( (symptomsOnsetMoment.isSame(startDate) || symptomsOnsetMoment.isAfter(startDate)) && (!endDate ||  symptomsOnsetMoment.isBefore(endDate))) {
                             angular.forEach(enrollment.events, function(event){
                                 if((!endDate || moment(event.eventDate).isBefore(endDate)) && moment(event.eventDate).isAfter(startDate)) {
                                     //Health condition:
@@ -523,7 +522,7 @@ trackerCapture.controller('RelationshipController',
         return programAttributes;
     };
     $scope.isDuplikatsjekk = function () {
-        return $scope.selectedProgram.id === DUPLIKAT_PROGRAM_ID;
+        return $scope.selectedProgram && $scope.selectedProgram.id === DUPLIKAT_PROGRAM_ID;
     };
 
     $scope.registerNewInInnreise = function () {


### PR DESCRIPTION
Add null check to prevent crash when contact does not have a date within the boundaries, and there is an end date set.

Fix indexes that has onset date outside the boundaries, so they will show up under contacts - with no contact date.

Add null check in unlelated function isDuplikatSjekk, to avoid log noise.