### PR TITLE
fix: Do not get prøversvar on return key in registration

### DIFF
--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -1,5 +1,6 @@
 <div ng-if="widget !== 'PROFILE' && trackedEntityTypes.selected" class="section-label section-spacing vertical-spacing">
-    {{'profile'| translate}}<button style="margin-left: 20px;margin-top:10px;" ng-click="showLabTest()" class="btn btn-secondary"  ng-show="(selectedTei['ZSt07qyq6Pt'].length == 11 || selectedTei['fkUN6jLp7K4'].length == 11) && editingDisabled">Vis prøvesvar</button>
+    {{'profile'| translate}}
+    <button style="margin-left: 20px;margin-top:10px;" ng-click="showLabTest()" class="btn btn-secondary"  ng-if="(selectedTei['ZSt07qyq6Pt'].length == 11 || selectedTei['fkUN6jLp7K4'].length == 11) && editingDisabled">Vis prøvesvar</button>
     <button style="margin-left: 20px;margin-top:10px" ng-if="selectedProgram.id == 'uYjxkTbwRNf' && selectedEnrollment.enrollment" ng-disabled="(selectedTei['ZSt07qyq6Pt'].length != 11 && !selectedTei['NI0QRzJvQ0k']) || !selectedTei['ENRjVGxVL6l'] || !selectedTei['sB1IHYu2xQT']" ng-click="sendNotification()" class="btn btn-secondary">Send klinikermelding</button>
     <p></p>
 </div>


### PR DESCRIPTION
Use ng-if instead of ng-show to remove the Prøvesvar-button from the DOM. This button caused problems with the return button in cases it was hidden (like in registration form).

Fixes SMITTE-153