### PR TITLE
fix: [DHIS2-11403] dep mgmnt to include bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/dhis2/tracker-capture-app#readme",
   "dependencies": {
     "angular-vs-repeat": "^2.0.9",
-    "d2-tracker": "35.0.5",
+    "d2-tracker": "35.0.6",
     "file-loader": "^1.1.11",
     "leaflet": "^1.3.1",
     "leaflet-contextmenu": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1330,10 +1330,10 @@ csso@~2.2.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-d2-tracker@35.0.5:
-  version "35.0.5"
-  resolved "https://registry.yarnpkg.com/d2-tracker/-/d2-tracker-35.0.5.tgz#fcfabeac490f3de5bb3c80c73fd965153acf0af7"
-  integrity sha512-+9Lz4LFFWeqGtCyngTzge4MZUrHHOjHFttZiLomcPb0ii1QRAZKOhDpAyFhnkV0T0tciu6Rug96ZQHT4GMGv9g==
+d2-tracker@35.0.6:
+  version "35.0.6"
+  resolved "https://registry.yarnpkg.com/d2-tracker/-/d2-tracker-35.0.6.tgz#f9654cc95108d4624397fda94d38309d082cf61f"
+  integrity sha512-0054zEO1GZn6FaSBu9yg2mXTQ70WqK4hjM10q34Nlyntnfh8qTTTXI8kjVD5egz6cF9ukK4FjVB92AwqdMb6Tw==
   dependencies:
     angular-vs-repeat "^2.0.9"
     gulp "^3.9.1"


### PR DESCRIPTION
Dep mgmnt to use latest version of d2-tracker. 
Actual change here: https://github.com/dhis2/d2-tracker/commit/226de5050475b48ba6577eb524e05a36040f4d32
