### PR TITLE
fix: (2.36) don't crash if a program doesn't have assigned orgUnits [DHIS2-11529]

### DIFF
--- a/core/tracker-capture.js
+++ b/core/tracker-capture.js
@@ -366,13 +366,13 @@ function getBatchPrograms( programs, batch )
                     type: 'GET',
                     data: 'programs=' + program.id
                 }).done( function( response ){
+                    var ou = {};
                     if( response[program.id] ){
-                        var ou = {};
                         _.each(_.values( response[program.id] ), function(o){
                             ou[o] = {id:o};
                         });
-                        program.organisationUnits = ou;
                     }
+                    program.organisationUnits = ou;
                     
                     if( program.programStages ){
                         program.programStages = _.sortBy( program.programStages, 'sortOrder' );

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,6 @@
 {
-    "version": "0.1",
+    "appType": "APP",
+    "version": "36.0.17",
     "name": "Tracker Capture",
     "description": "Tracker Capture App",
     "launch_path": "index.html",
@@ -17,5 +18,7 @@
         "dhis": {
             "href": ".."
         }
-    }
+    },
+    "short_name": "tracker-capture",
+    "core_app": true
 }

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -500,7 +500,7 @@ var trackerCaptureServices = angular.module('trackerCaptureServices', ['ngResour
                         var programs = [];
                         angular.forEach(prs, function(pr){
                             if( (loadSelectedProgram && selectedProgram && pr.id == selectedProgram.id) || 
-                                (pr.organisationUnits.hasOwnProperty( ou.id ) && accesses.programsById[pr.id] && accesses.programsById[pr.id].data.read) ){
+                                (pr.organisationUnits && pr.organisationUnits.hasOwnProperty( ou.id ) && accesses.programsById[pr.id] && accesses.programsById[pr.id].data.read) ){
                                 if(pr.programTrackedEntityAttributes){
                                     pr.programTrackedEntityAttributes = pr.programTrackedEntityAttributes.filter(function(attr){
                                         return attr.access && attr.access.read;


### PR DESCRIPTION
This fixes a critical issue which would cause NO programs to be available if ANY programs did not have any assigned org units.  Discovered by the team in Ghana in 2.36.3, fixed with a hotfix build of Tracker Capture including these changes.