### PR TITLE
feat: Show error message even if logged out of Fiks

### DIFF
--- a/components/naerkontakt_import/naerkontakt-import.html
+++ b/components/naerkontakt_import/naerkontakt-import.html
@@ -7,7 +7,7 @@
     <div ng-if="stage === 'start'">
         <p>Her kan du laste opp en liste med nærkontakter (klasseliste) fra regneark, og knytte de automatisk til
             klyngen.</p>
-        <p>Bruk denne malen for å fylle ut listen: <a href="/api/import/excelmal">mal.xls</a></p>
+        <p>Bruk denne malen for å fylle ut listen: <a href="/api/import/excelmal">mal.xlsx</a></p>
         <p>Vi vil først verifisere listen. Du vil få se hvilke personer som kan importeres, deretter bestemmer du om
             disse skal importeres i klyngen eller ikke.</p>
         <button class="btn btn-grp btn-file">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -138,6 +138,12 @@ angular.module('trackerCapture')
     $http.get('components/dataentry/section-inner-form.html').then(function(page){
         $templateCache.put('components/dataentry/section-inner-form.html', page.data);
     });
+    $http.get('views/dialog.html').then(function(page){
+        $templateCache.put('views/dialog.html', page.data);
+    });
+    $http.get('views/modal-body.html').then(function(page){
+        $templateCache.put('views/modal-body.html', page.data);
+    });
 
     $rootScope.maxGridColumnSize = 1;
     $rootScope.maxOptionSize = 100;


### PR DESCRIPTION
If the user is logged out from Fiks, the html files will not be acceptable. This is a problem, as the template html for the error modal is lazy loaded.
We solve this by putting the templates in cache on startup.