### PR TITLE
fix: add created:desc as a secondary search criteria when fetching a …

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -2981,7 +2981,7 @@ var trackerCaptureServices = angular.module('trackerCaptureServices', ['ngResour
             searchParams.programUrl += "&followUp=true"
         }
         if(sortColumn){
-            searchParams.sortUrl = "&order="+sortColumn.id+':'+sortColumn.direction;
+            searchParams.sortUrl = "&order="+sortColumn.id+':'+sortColumn.direction + ',created:desc';
         }
         if(workingList.id === 'vo6JLWsbyMj') { //ikke sendte klinikermeldinger
             searchParams.programUrl += '&filter=C225m3EOPRo:IN:false';


### PR DESCRIPTION
…working list

created:desc is not set for search operations (programScopeSearch and tetScopeSearch)

An interesting edge case would be order=created:asc,created:desc, but it seemed to work fine.