### PR TITLE
fix: [DHIS2-7869] display rule effects in feedback widget

### DIFF
--- a/components/dataentry/dataentry-controller.js
+++ b/components/dataentry/dataentry-controller.js
@@ -1457,6 +1457,7 @@ trackerCapture.controller('DataEntryController',
         $scope.currentEvent = null;
         $scope.currentElement = {id: '', saved: false};
         $scope.showDataEntryDiv = !$scope.showDataEntryDiv;
+        $rootScope.$broadcast("dataEntryEventChanged", {event: null});
     };
     
     $scope.tableRowIsEditable = function(eventRow){
@@ -3268,6 +3269,14 @@ trackerCapture.controller('DataEntryController',
             $scope.stageOpenInEventLayout = "";            
         }
     });
+
+    $scope.$watch(function(scope) {
+        return scope.currentEvent && scope.currentEvent.status;
+    }, function(newValue, oldValue) {
+        if(newValue){
+            $scope.executeRules(); // needed by rules using e.g. V{event_status}
+        }
+    })
     
     $scope.getValueTitleCompareForm = function(event){
 	return event.eventDate;

--- a/components/rulebound/rulebound-controller.js
+++ b/components/rulebound/rulebound-controller.js
@@ -52,7 +52,9 @@ trackerCapture.controller('RuleBoundController',
 
         //listen for updated rule effects
     $scope.$on('ruleeffectsupdated', function(event, args) {
-        setOrderedData(RuleBoundFactory.getDisplayEffects($scope.data, args.event, $rootScope.ruleeffects, $scope.widgetTitle));
+        if(currentEventId && currentEventId === args.event){
+            setOrderedData(RuleBoundFactory.getDisplayEffects($scope.data, args.event, $rootScope.ruleeffects, $scope.widgetTitle));
+        }
     });
 
     $scope.$on('dataEntryEventChanged', function(event,args){

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -3238,7 +3238,7 @@ var trackerCaptureServices = angular.module('trackerCaptureServices', ['ngResour
             ruleBoundData.textInEffect = false;
             ruleBoundData.keyDataInEffect = false;
 
-            if(event === 'registration') return;
+            if(!event || event === 'registration') return;
     
             //In case the 
             if(ruleBoundData.lastEventUpdated !== event) {


### PR DESCRIPTION
By using `$scope.$watch` on `scope.currentEvent.status`, the rules engine will automatically be triggered when the event status changes into _any_ new value, which I believe is what we generally would want to happen.