### PR TITLE
fix: [DHIS2-13617] show warnings and errors on non-empty fields

### DIFF
--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -384,7 +384,7 @@
                         </span>
                     </span>
                 </span>
-                <div ng-messages="innerForm.foo.$error" ng-if="showFieldIssues(innerForm.foo)" class="required hideInPrint" ng-messages-include="../dhis-web-commons/angular-forms/error-messages.html">
+                <div ng-messages="innerForm.foo.$error" class="required hideInPrint" ng-messages-include="../dhis-web-commons/angular-forms/error-messages.html">
                     <div class="alert alert-warning alert-dismissible" role="alert" ng-if="warningMessages[attribute.id]">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close" tabindex="-1"><span aria-hidden="true">&times;</span></button>
                         {{warningMessages[attribute.id]}}

--- a/components/registration/default-registration-form.html
+++ b/components/registration/default-registration-form.html
@@ -384,7 +384,7 @@
                         </span>
                     </span>
                 </span>
-                <div ng-messages="innerForm.foo.$error" ng-if="interacted(innerForm.foo)" class="required hideInPrint" ng-messages-include="../dhis-web-commons/angular-forms/error-messages.html">
+                <div ng-messages="innerForm.foo.$error" ng-if="showFieldIssues(innerForm.foo)" class="required hideInPrint" ng-messages-include="../dhis-web-commons/angular-forms/error-messages.html">
                     <div class="alert alert-warning alert-dismissible" role="alert" ng-if="warningMessages[attribute.id]">
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close" tabindex="-1"><span aria-hidden="true">&times;</span></button>
                         {{warningMessages[attribute.id]}}

--- a/components/registration/registration-controller.js
+++ b/components/registration/registration-controller.js
@@ -913,10 +913,6 @@ trackerCapture.controller('RegistrationController',
         }
     });
 
-    $scope.showFieldIssues = function(field) {
-        return field.$modelValue || $scope.interacted(field);
-    }
-
     $scope.interacted = function (field) {
         var status = false;
         if (field) {

--- a/components/registration/registration-controller.js
+++ b/components/registration/registration-controller.js
@@ -913,6 +913,10 @@ trackerCapture.controller('RegistrationController',
         }
     });
 
+    $scope.showFieldIssues = function(field) {
+        return field.$modelValue || $scope.interacted(field);
+    }
+
     $scope.interacted = function (field) {
         var status = false;
         if (field) {


### PR DESCRIPTION
Previous behavior was that warnings/errors were only shown under form fields that had been recently edited or submitted.
This PR extends this list of conditions to include any non-empty fields as well.