### PR TITLE
fix: [DHIS2-14265] period change when periodOffset undefined

### DIFF
--- a/components/dataentry/new-event-controller.js
+++ b/components/dataentry/new-event-controller.js
@@ -315,7 +315,8 @@ trackerCapture.controller('EventCreationController',
             return;
         }
         
-        $scope.periodOffset = period === 'NEXT' ? $scope.periodOffset + 1 : $scope.periodOffset - 1;
+        const periodOffset = $scope.periodOffset || 0
+        $scope.periodOffset = period === 'NEXT' ? periodOffset + 1 : periodOffset - 1;
         $scope.dhis2Event.selectedPeriod = null;
         
         var prds = PeriodService.getPeriods(eventsByStage[stage.id], $scope.model.selectedStage, $scope.selectedEnrollment, $scope.periodOffset);

--- a/components/dataentry/new-event-controller.js
+++ b/components/dataentry/new-event-controller.js
@@ -315,7 +315,7 @@ trackerCapture.controller('EventCreationController',
             return;
         }
         
-        const periodOffset = $scope.periodOffset || 0
+        const periodOffset = $scope.periodOffset || 0;
         $scope.periodOffset = period === 'NEXT' ? periodOffset + 1 : periodOffset - 1;
         $scope.dhis2Event.selectedPeriod = null;
         


### PR DESCRIPTION
When $scope.periodOffset is undefined the period change action fails because for example undefined + 1 is NaN where as 1 is the expected result.