### PR TITLE
fix: [DHIS2-14596] use English as fallback in date picker

### DIFF
--- a/d2-tracker/dhis2.angular.services.js
+++ b/d2-tracker/dhis2.angular.services.js
@@ -133,6 +133,8 @@ var d2Services = angular.module('d2Services', ['ngResource'])
 
 /* service for getting calendar setting */
 .service('CalendarService', function (storage, SessionStorageService, $rootScope) {
+    // The following array should be manually kept in sync with the one in `index.ejs`
+    const supportedCalendarLocales = ['ar', 'ar-EG', 'zn-CH', 'cs', 'da', 'nl', 'fr', 'km', 'lo', 'nb', 'pt-BR', 'ro', 'ru', 'es', 'sv', 'uk', 'ur', 'vi'];
 
     return {
         getSetting: function () {
@@ -142,6 +144,9 @@ var d2Services = angular.module('d2Services', ['ngResource'])
             var userSettings = SessionStorageService.get('USER_SETTING');
 
             dhis2CalendarFormat.locale = userSettings.keyUiLocale.replace('_', '-');
+            if (!supportedCalendarLocales.find(locale => locale === dhis2CalendarFormat.locale)) {
+                dhis2CalendarFormat.locale = 'en';
+            }
             
             if (angular.isObject(storedFormat) && storedFormat.keyDateFormat && storedFormat.keyCalendar) {
                 if (storedFormat.keyCalendar === 'iso8601') {

--- a/index.ejs
+++ b/index.ejs
@@ -52,6 +52,7 @@
         <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars.plus.min.js"></script>
         <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars.picker.ext.js"></script>
 
+        <!-- The following array should be manually kept in sync with the one in `CalendarService` -->
         <% const supportedCalendarLocales = ['ar', 'ar-EG', 'zn-CH', 'cs', 'da', 'nl', 'fr', 'km', 'lo', 'nb', 'pt-BR', 'ro', 'ru', 'es', 'sv', 'uk', 'ur', 'vi']; %>
         <% supportedCalendarLocales.forEach(locale => { %>
             <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars-<%= locale %>.js"></script>

--- a/index.ejs
+++ b/index.ejs
@@ -52,7 +52,7 @@
         <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars.plus.min.js"></script>
         <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars.picker.ext.js"></script>
 
-        <% const supportedCalendarLocales = ['ar', 'ar-EG', 'zn-CH', 'cs', 'da', 'nl', 'fr', 'km', 'lo', 'pt-BR', 'ro', 'ru', 'es', 'sv', 'uk', 'ur', 'vi']; %>
+        <% const supportedCalendarLocales = ['ar', 'ar-EG', 'zn-CH', 'cs', 'da', 'nl', 'fr', 'km', 'lo', 'nb', 'pt-BR', 'ro', 'ru', 'es', 'sv', 'uk', 'ur', 'vi']; %>
         <% supportedCalendarLocales.forEach(locale => { %>
             <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars-<%= locale %>.js"></script>
             <script src="vendor/jquery.calendars.package-1.2.1/jquery.calendars.picker-<%= locale %>.js"></script>

--- a/vendor/jquery.calendars.package-1.2.1/jquery.calendars-nb.js
+++ b/vendor/jquery.calendars.package-1.2.1/jquery.calendars-nb.js
@@ -2,7 +2,7 @@
    Norwegian localisation for Gregorian/Julian calendars for jQuery.
    Written by Naimdjon Takhirov (naimdjon@gmail.com). */
 (function($) {
-	$.calendars.calendars.gregorian.prototype.regional['no'] = {
+	$.calendars.calendars.gregorian.prototype.regional['nb'] = {
 		name: 'Gregorian',
 		epochs: ['BCE', 'CE'],
 		monthNames: ['Januar','Februar','Mars','April','Mai','Juni',
@@ -17,7 +17,7 @@
 		isRTL: false
 	};
 	if ($.calendars.calendars.julian) {
-		$.calendars.calendars.julian.prototype.regional['no'] =
-			$.calendars.calendars.gregorian.prototype.regional['no'];
+		$.calendars.calendars.julian.prototype.regional['nb'] =
+			$.calendars.calendars.gregorian.prototype.regional['nb'];
 	}
 })(jQuery);

--- a/vendor/jquery.calendars.package-1.2.1/jquery.calendars.picker-nb.js
+++ b/vendor/jquery.calendars.package-1.2.1/jquery.calendars.picker-nb.js
@@ -2,7 +2,7 @@
    Norwegian localisation for calendars datepicker for jQuery.
    Written by Naimdjon Takhirov (naimdjon@gmail.com). */
 (function($) {
-	$.calendars.picker.regional['no'] = {
+	$.calendars.picker.regional['nb'] = {
 		renderer: $.calendars.picker.defaultRenderer,
 		prevText: '&laquo;Forrige',  prevStatus: '',
 		prevJumpText: '&#x3c;&#x3c;', prevJumpStatus: '',
@@ -17,5 +17,5 @@
 		dayStatus: 'DD, M d', defaultStatus: '',
 		isRTL: false
 	};
-	$.calendars.picker.setDefaults($.calendars.picker.regional['no']);
+	$.calendars.picker.setDefaults($.calendars.picker.regional['nb']);
 })(jQuery);


### PR DESCRIPTION
Features a couple of questionable solutions:
- Introduces an identical array in two different files
- Renames the Norwegian translation files ('no' -> 'nb')