### PR TITLE
fix: [DHIS2-15500] use `displayFormName` instead of `formName`

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -2144,7 +2144,7 @@ var trackerCaptureServices = angular.module('trackerCaptureServices', ['ngResour
             angular.forEach(attributes, function(attr){
                 if(attr.displayInListNoProgram){
                     gridColumnIndex++;
-                    var gridColumn = {id: attr.id, displayName: attr.displayName, formName: attr.formName, show: false, valueType: attr.valueType};
+                    var gridColumn = {id: attr.id, displayName: attr.displayName, displayFormName: attr.displayFormName, show: false, valueType: attr.valueType};
                     setShowGridColumn(gridColumn,gridColumnIndex, config, savedGridColumnsKeyMap);
                     gridColumns.push(gridColumn);
                 }


### PR DESCRIPTION
Fixes a detail that was missed in [DHIS2-9190](https://dhis2.atlassian.net/browse/DHIS2-9190)

[DHIS2-9190]: https://dhis2.atlassian.net/browse/DHIS2-9190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ