### PR TITLE
fix: [DHIS2-17301] prevent adding event to program stage bug

### DIFF
--- a/components/dataentry/dataentry-controller.js
+++ b/components/dataentry/dataentry-controller.js
@@ -330,20 +330,21 @@ trackerCapture.controller('DataEntryController',
 
     //Adds support for HIDEPROGRAMSTAGE even if no event exists in enrollment
     var processRegistrationRuleEffect = function(event, callerId){
+        $scope.stagesNotShowingInStageTasks = {};
+
         angular.forEach($rootScope.ruleeffects[event], function(effect){
             if (effect.action === "HIDEPROGRAMSTAGE") {
                 if (effect.programStage) {
-                    if($scope.stagesNotShowingInStageTasks[effect.programStage.id] !== effect.ineffect )
-                    {
-                        $scope.stagesNotShowingInStageTasks[effect.programStage.id] = effect.ineffect;
+                    if(effect.ineffect) {
+                        $scope.stagesNotShowingInStageTasks[effect.programStage.id] = true;
                     }
-                    updateTabularEntryStages();
                 }
                 else {
                     $log.warn("ProgramRuleAction " + effect.id + " is of type HIDEPROGRAMSTAGE, bot does not have a stage defined");
                 }
             }
         });
+        updateTabularEntryStages();
     }
 
     var processRuleEffect = function(event, callerId){
@@ -378,7 +379,8 @@ trackerCapture.controller('DataEntryController',
         $scope.errorMessages[event] = [];
         $scope.hiddenFields[event] = [];
         $scope.mandatoryFields[event] = [];
-        $scope.optionVisibility[event] = { showOnly: null, hidden: {}};;
+        $scope.optionVisibility[event] = { showOnly: null, hidden: {}};
+        $scope.stagesNotShowingInStageTasks = {};
         
         var dataElementOptionsChanged = [];
 
@@ -495,9 +497,8 @@ trackerCapture.controller('DataEntryController',
             }
             else if (effect.action === "HIDEPROGRAMSTAGE") {
                 if (effect.programStage) {
-                    if($scope.stagesNotShowingInStageTasks[effect.programStage.id] !== effect.ineffect )
-                    {
-                        $scope.stagesNotShowingInStageTasks[effect.programStage.id] = effect.ineffect;
+                    if(effect.ineffect) {
+                        $scope.stagesNotShowingInStageTasks[effect.programStage.id] = true;
                     }
                 }
                 else {


### PR DESCRIPTION
If multiple "Prevent adding new events to stage" actions are targeting the same program stage, then the stage should be blocked whenever at least one of these actions is in effect. Currently these actions are handled such that the stage gets blocked or unblocked depending on the `inEffect` state of the *last processed* "Prevent adding new events to stage" action.