### PR TITLE
fix: event reference in setFileName

### DIFF
--- a/d2-tracker/dhis2.angular.services.js
+++ b/d2-tracker/dhis2.angular.services.js
@@ -495,10 +495,10 @@ var d2Services = angular.module('d2Services', ['ngResource'])
         var fileNames = CurrentSelection.getFileNames() || {};
         FileService.get(valueId).then(function(response){
             if(response && response.displayName){
-                if(!fileNames[event.event]){
-                    fileNames[event.event] = {};
+                if(!fileNames[event]){
+                    fileNames[event] = {};
                 }
-                fileNames[event.event][dataElementId] = response.displayName;
+                fileNames[event][dataElementId] = response.displayName;
                 CurrentSelection.setFileNames( fileNames );
             }
         });


### PR DESCRIPTION
In file dhis2.angular.services.js, the function `setFileName(event, ...)`, which is used only when `dataElement.valueType == "FILE_RESOURCE"`, performs `event.event`, but `event` is already a string, so `event.event` results in `undefined`. The result is that link has no text and it's not possible to download the file.